### PR TITLE
Mejora de funcionamiento y estética

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,29 @@
+# Tips
+
+## Docker ps
+
+`docker ps -a --format "table {{.ID}} {{.Names}}\\t{{.Image}}\\t{{.Ports}}\\t{{.Size}}\\t{{.Status}}\\t{{.RunningFor}}"`
+
+```shell
+CONTAINER ID NAMES              IMAGE                                        PORTS                                                        SIZE                    STATUS                    CREATED
+490120f798ee pihole_pi-hole_1   diginc/pi-hole-multiarch:v3.3_debian_armhf   0.0.0.0:53->53/tcp, 0.0.0.0:80->80/tcp, 0.0.0.0:53->53/udp   298kB (virtual 311MB)   Up 26 minutes (healthy)   26 minutes ago
+e4f42699c7b6 portainer_ui_1     portainer/portainer:1.19.1                   0.0.0.0:9000->9000/tcp                                       0B (virtual 49.3MB)     Up 28 minutes             28 minutes ago
+```
+
+Es posible ponerte este comando en un alias o añadir el formato a `$HOME/.docker/config.json` para alterar el formato predeterminado de `docker ps`.
+
+Al usar el alias es necesario poner `\"` para utilizar `"` dentro del comando.
+
+```shell
+alias dockerps="docker ps -a --format \"table {{.ID}} {{.Names}}\\t{{.Image}}\\t{{.Ports}}\\t{{.Size}}\\t{{.Status}}\\t{{.RunningFor}}\""
+```
+
+`$HOME/.docker/config.json`
+
+```json
+{
+    ...
+    "psFormat": "table {{.ID}} {{.Names}}\\t{{.Image}}\\t{{.Ports}}\\t{{.Size}}\\t{{.Status}}\\t{{.RunningFor}}",
+    ...
+}
+```

--- a/Docker/jenkins/docker-compose.armhf.yml
+++ b/Docker/jenkins/docker-compose.armhf.yml
@@ -5,7 +5,7 @@ services:
     restart: always
     build: . 
     ports:
-      - 8080:8080
+      - "8080:8080"
     volumes:
       - /mnt/archive/jenkins:/usr/local/jenkins
       - /var/run/docker.sock:/var/run/docker.sock

--- a/Docker/jenkins/docker-compose.yml
+++ b/Docker/jenkins/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     environment:
       JAVA_OPTS: "-Djava.awt.headless=true"
     ports:
-      - 8080:8080
-      - 5000:5000
+      - "8080:8080"
+      - "5000:5000"
     volumes:
       - vol:/var/jenkins_home
       - /var/run/docker.sock:/var/run/docker.sock

--- a/Docker/mysql-phpmyadmin/docker-compose.yml
+++ b/Docker/mysql-phpmyadmin/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       #ports:
       #  - "3306:3306"
 
-      # No es neceario porque la imagen mysql:5.7.22 ya incluye un expose
+      # No es necesario porque la imagen mysql:5.7.22 ya incluye un expose
       #expose:
       #  - "3306"
       networks:

--- a/Docker/pi-hole/docker-compose.armhf.yml
+++ b/Docker/pi-hole/docker-compose.armhf.yml
@@ -6,16 +6,16 @@ services:
     #container_name: pi-hole
     restart: unless-stopped
     ports:
-     - 53:53/tcp
-     - 53:53/udp
-     - 80:80
-    # - 67:67/udp #DHCP
-    # - 443:443 #SSL, ver dockerhub para mas info
+     - "53:53/tcp"
+     - "53:53/udp"
+     - "80:80"
+    # - "67:67/udp" #DHCP
+    # - "443:443" #SSL, ver dockerhub para mas info
     # Por si se quieren poner las env variables en un archivo .env
     #env_file:
     #  - .env
     environment:
-      ServerIP: $IP
+      ServerIP: ${IP:?err}
       WEBPASSWORD: pi123
       TZ: America/Bogota
     volumes:

--- a/Docker/pi-hole/docker-compose.yml
+++ b/Docker/pi-hole/docker-compose.yml
@@ -6,16 +6,16 @@ services:
     #container_name: pi-hole
     restart: unless-stopped
     ports:
-     - 53:53/tcp
-     - 53:53/udp
-     - 80:80
-    # - 67:67/udp #DHCP
-    # - 443:443 #SSL, ver dockerhub para mas info
+     - "53:53/tcp"
+     - "53:53/udp"
+     - "80:80"
+    # - "67:67/udp" #DHCP
+    # - "443:443" #SSL, ver dockerhub para mas info
     # Por si se quieren poner las env variables en un archivo .env
     #env_file:
     #  - .env
     environment:
-      ServerIP: $IP
+      ServerIP: ${IP:?err}
       WEBPASSWORD: pi123
       TZ: America/Bogota
     volumes:

--- a/Docker/portainer/docker-compose.armhf.yml
+++ b/Docker/portainer/docker-compose.armhf.yml
@@ -4,9 +4,7 @@ services:
     image: portainer/portainer:linux-arm-1.19.1
     restart: unless-stopped
     ports:
-      - 9000:9000
-    #expose:
-    #  - 9000
+      - "${IP:?err}:9000:9000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - data:/data

--- a/Docker/portainer/docker-compose.yml
+++ b/Docker/portainer/docker-compose.yml
@@ -4,9 +4,7 @@ services:
     image: portainer/portainer:1.19.1
     restart: unless-stopped
     ports:
-      - 9000:9000
-    #expose:
-    #  - 9000
+      - "${IP:?err}:9000:9000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - data:/data


### PR DESCRIPTION
 - Sustitución de variables de entorno. Si la variable no se encuentra en el entorno o esta en blanco, dará error. Ver otras formas de usar en [doc]( https://docs.docker.com/compose/compose-file/#variable-substitution)
   - Portainer: El entrypoint local que obtiene portainer usando el socket de docker, no tiene IP publica por defecto. Aparecía 0.0.0.0 y debería aparecer algo parecido a esto: ![Ejemplo](https://user-images.githubusercontent.com/21027839/29706462-362443cc-8982-11e7-8e27-f44c552e21a0.PNG) Esto afectabá la dirección IP al inspeccionar los contenedores por los puertos expuestos.
   - pi-hole: Evitar que la variable ServerIP que es inicializada por IP, este en blanco
 - Limpieza
   - Texto innecesario en portainer
   - Typo en mysql-phpmyadmin
   - Uso correcto de "" en ports de jenkins, pi-hole
 - Docker/README.md: Tips para docker ps, como manipular docker ps
 format